### PR TITLE
RFC: improve usability by allowing members and admins to be defined as a list

### DIFF
--- a/examples/organization/main.tf
+++ b/examples/organization/main.tf
@@ -11,13 +11,8 @@ module "organization" {
   source = "../.."
 
   members = [
-    {
-      username = "terraform-test-user-1"
-    },
-    {
-      username = "terraform-test-user-2"
-      role     = "member"
-    }
+    "terraform-test-user-1",
+    "terraform-test-user-2",
   ]
 
   # randomly chosen users, sorry for blocking you guys!

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,15 @@
 locals {
-  members = { for i in var.members : lower(i.username) => merge({
-    username = null
-    role     = "member"
-  }, i) }
+  admins  = { for i in var.admins : lower(i) => "admin" }
+  members = { for i in var.members : lower(i) => "member" }
+
+  memberships = merge(local.admins, local.members)
 }
 
 resource "github_membership" "membership" {
-  for_each = local.members
+  for_each = local.memberships
 
-  username = each.value.username
-  role     = each.value.role
+  username = each.key
+  role     = each.value
 }
 
 resource "github_organization_block" "blocked_user" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,29 +5,15 @@ variable "blocked_users" {
 }
 
 variable "members" {
-  type = list(any)
-
-  # We can't use a detailed type specification due to a terraform limitation. However, this might be changed in a future
-  # Terraform version. See https://github.com/hashicorp/terraform/issues/19898 and https://github.com/hashicorp/terraform/issues/22449
-  #
-  # type = list(object({
-  #   username = string
-  #   role     = optional(string)
-  # }))
-  description = "A list of users to be added from your organization. When applied, an invitation will be sent to the user to become part of the organization. When destroyed, either the invitation will be cancelled or the user will be removed. Role must be one of member or admin. Defaults to member."
+  type        = list(string)
+  description = "A list of users to be added to your organization with member role. When applied, an invitation will be sent to the user to become part of the organization. When destroyed, either the invitation will be cancelled or the user will be removed."
   default     = []
+}
 
-  # Example:
-  # members = [
-  #   {
-  #     username   = "username1"
-  #     role       = "member"
-  #   },
-  #   {
-  #     username   = "username2"
-  #     role       = "admin"
-  #   }
-  # ]
+variable "admins" {
+  type        = list(string)
+  description = "A list of users to be added to your organization with admin role. When applied, an invitation will be sent to the user to become part of the organization. When destroyed, either the invitation will be cancelled or the user will be removed."
+  default     = []
 }
 
 variable "projects" {


### PR DESCRIPTION
this is a backwards incompatible change that increases usability by
changing the members variable and introducing an admins variable
each defining a list(string) of usernames instead of a list(map).

    members = [ "user1", "user2" ]
    admins  = [ "user3", "user4" ]

instead of

    members = [
      {
         username = "user1",
         role     = "member",
      },
      {
         username = "user2",
         role     = "member",
      },
      {
         username = "user3",
         role     = "admin",
      },
      {
         username = "user4",
         role     = "admin",
      },
    ]